### PR TITLE
쿠버네티스 작업 후 서버 테스트 중 발생한 이슈 fix

### DIFF
--- a/src/main/java/com/team7/spliito_server/dto/CreateGroupRequest.java
+++ b/src/main/java/com/team7/spliito_server/dto/CreateGroupRequest.java
@@ -10,13 +10,13 @@ public class CreateGroupRequest {
     private String groupName;
 
     @NotEmpty(message = "Member names cannot be empty")  // 리스트가 비어 있거나 null일 경우 오류 발생
-    private List<String> memberNames;  // 멤버 이름 목록
+    private List<String> memberName;  // 멤버 이름 목록
 
     public CreateGroupRequest() {}
 
-    public CreateGroupRequest(String groupName, List<String> memberNames) {
+    public CreateGroupRequest(String groupName, List<String> memberName) {
         this.groupName = groupName;
-        this.memberNames = memberNames;
+        this.memberName = memberName;
     }
 
     public String getGroupName() {
@@ -27,11 +27,11 @@ public class CreateGroupRequest {
         this.groupName = groupName;
     }
 
-    public List<String> getMemberNames() {
-        return memberNames;
+    public List<String> getMemberName() {
+        return memberName;
     }
 
-    public void setMemberNames(List<String> memberNames) {
-        this.memberNames = memberNames;
+    public void setMemberName(List<String> memberName) {
+        this.memberName = memberName;
     }
 }

--- a/src/main/java/com/team7/spliito_server/model/Group.java
+++ b/src/main/java/com/team7/spliito_server/model/Group.java
@@ -33,7 +33,7 @@ public class Group extends BaseEntity {
         this.name = name;
         this.createdDate = createdDate;
     }
-    
+
     public GroupMetaInfoResponse toGroupMetaInfoResponse(List<String> userNames) {
         return new GroupMetaInfoResponse(name, createdDate, userNames);
     }

--- a/src/main/java/com/team7/spliito_server/model/Group.java
+++ b/src/main/java/com/team7/spliito_server/model/Group.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "`group`") // 예약어 충돌 방지
-public class Group extends BaseEntity{
+public class Group extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)  // ID 자동 생성
@@ -29,17 +29,11 @@ public class Group extends BaseEntity{
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<User> members = new ArrayList<>();
 
-
-    public Group(String name) {
-        this.name = name;
-    }
-
-    @Builder
-    private Group(String name, LocalDateTime createdDate) {
+    public Group(String name, LocalDateTime createdDate) {
         this.name = name;
         this.createdDate = createdDate;
     }
-
+    
     public GroupMetaInfoResponse toGroupMetaInfoResponse(List<String> userNames) {
         return new GroupMetaInfoResponse(name, createdDate, userNames);
     }

--- a/src/main/java/com/team7/spliito_server/service/GroupService.java
+++ b/src/main/java/com/team7/spliito_server/service/GroupService.java
@@ -34,7 +34,7 @@ public class GroupService {
     public String createOrUpdateGroup(CreateGroupRequest request) {
         // 기존 그룹이 존재하면 가져오고, 없으면 새로 생성
         Group group = groupRepository.findByName(request.getGroupName())
-                .orElseGet(() -> new Group(request.getGroupName()));
+                .orElseGet(() -> new Group(request.getGroupName(), LocalDateTime.now()));
 
         // 기존 멤버 이름 목록을 수집하여, 중복 추가를 방지
         List<String> existingMemberNames = group.getMembers() != null ?

--- a/src/main/java/com/team7/spliito_server/service/GroupService.java
+++ b/src/main/java/com/team7/spliito_server/service/GroupService.java
@@ -44,7 +44,7 @@ public class GroupService {
                 : List.of(); // 새 그룹이면 빈 리스트로 초기화
 
         // 요청된 멤버 이름 중 기존에 없는 멤버만 추가
-        List<User> newMembers = request.getMemberNames().stream()
+        List<User> newMembers = request.getMemberName().stream()
                 .filter(name -> !existingMemberNames.contains(name)) // 기존 멤버와 중복되지 않는 이름만 추가
                 .map(name -> new User(name, group))
                 .toList();

--- a/src/test/java/com/team7/spliito_server/GroupApiIntegrationTest.java
+++ b/src/test/java/com/team7/spliito_server/GroupApiIntegrationTest.java
@@ -50,7 +50,7 @@ class GroupApiIntegrationTest extends IntegrationTestSupport {
     void testCreateGroupApi() throws Exception {
         CreateGroupRequest request = new CreateGroupRequest();
         request.setGroupName("Integration Test Group");
-        request.setMemberNames(List.of("A", "B"));
+        request.setMemberName(List.of("A", "B"));
 
         mockMvc.perform(post("/group")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -64,7 +64,7 @@ class GroupApiIntegrationTest extends IntegrationTestSupport {
     void testCreateGroupApiInvalidRequest() throws Exception {
         CreateGroupRequest invalidRequest = new CreateGroupRequest();
         invalidRequest.setGroupName("");  // empty group name
-        invalidRequest.setMemberNames(List.of("A", "B"));
+        invalidRequest.setMemberName(List.of("A", "B"));
 
         mockMvc.perform(post("/group")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -77,11 +77,11 @@ class GroupApiIntegrationTest extends IntegrationTestSupport {
     void testGetAllGroupsApi() throws Exception {
         CreateGroupRequest request1 = new CreateGroupRequest();
         request1.setGroupName("Group 1");
-        request1.setMemberNames(List.of("A", "B"));
+        request1.setMemberName(List.of("A", "B"));
 
         CreateGroupRequest request2 = new CreateGroupRequest();
         request2.setGroupName("Group 2");
-        request2.setMemberNames(List.of("C", "D"));
+        request2.setMemberName(List.of("C", "D"));
 
         mockMvc.perform(post("/group")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/team7/spliito_server/GroupServiceTest.java
+++ b/src/test/java/com/team7/spliito_server/GroupServiceTest.java
@@ -108,9 +108,9 @@ class GroupServiceTest extends IntegrationTestSupport {
         // given
         LocalDateTime now = LocalDateTime.of(2024, 10, 27, 0, 0, 0);
 
-        Group g1 = makeGroup("g1", now);
-        Group g2 = makeGroup("g2", now.plusDays(1));
-        Group g3 = makeGroup("g3", now.plusDays(2));
+        Group g1 = new Group("g1", now);
+        Group g2 = new Group("g2", now.plusDays(1));
+        Group g3 = new Group("g3", now.plusDays(2));
         List<Group> groups = groupRepository.saveAll(List.of(g1, g2, g3));
 
         User u1 = new User("u1", groups.get(0));
@@ -134,12 +134,5 @@ class GroupServiceTest extends IntegrationTestSupport {
 
         assertThat(result.getMemberName()).hasSize(2)
                 .containsExactlyInAnyOrder("u5", "u6");
-    }
-
-    public static Group makeGroup(String name, LocalDateTime createdDate) {
-        return Group.builder()
-                .name(name)
-                .createdDate(createdDate)
-                .build();
     }
 }

--- a/src/test/java/com/team7/spliito_server/GroupServiceTest.java
+++ b/src/test/java/com/team7/spliito_server/GroupServiceTest.java
@@ -56,7 +56,7 @@ class GroupServiceTest extends IntegrationTestSupport {
         // given
         CreateGroupRequest request = new CreateGroupRequest();
         request.setGroupName("Test Group");
-        request.setMemberNames(List.of("A", "B"));
+        request.setMemberName(List.of("A", "B"));
 
         // when
         String groupUrl = groupService.createOrUpdateGroup(request);
@@ -80,13 +80,13 @@ class GroupServiceTest extends IntegrationTestSupport {
         // given
         CreateGroupRequest initialRequest = new CreateGroupRequest();
         initialRequest.setGroupName("Test Group");
-        initialRequest.setMemberNames(List.of("A"));
+        initialRequest.setMemberName(List.of("A"));
 
         groupService.createOrUpdateGroup(initialRequest); // 초기 그룹 생성
 
         CreateGroupRequest updateRequest = new CreateGroupRequest();
         updateRequest.setGroupName("Test Group");
-        updateRequest.setMemberNames(List.of("A", "B", "C"));
+        updateRequest.setMemberName(List.of("A", "B", "C"));
 
         // when
         String updatedGroupUrl = groupService.createOrUpdateGroup(updateRequest);

--- a/src/test/java/com/team7/spliito_server/repository/UserRepositoryTest.java
+++ b/src/test/java/com/team7/spliito_server/repository/UserRepositoryTest.java
@@ -34,9 +34,9 @@ class UserRepositoryTest extends IntegrationTestSupport {
         // given
         LocalDateTime now = LocalDateTime.of(2024, 10, 28, 0, 0, 0);
 
-        Group g1 = makeGroup("g1", now);
-        Group g2 = makeGroup("g2", now.plusDays(1));
-        Group g3 = makeGroup("g3", now.plusDays(2));
+        Group g1 = new Group("g1", now);
+        Group g2 = new Group("g2", now.plusDays(1));
+        Group g3 = new Group("g3", now.plusDays(2));
         List<Group> groups = groupRepository.saveAll(List.of(g1, g2, g3));
 
         User u1 = new User("u1", groups.get(0));
@@ -78,12 +78,5 @@ class UserRepositoryTest extends IntegrationTestSupport {
 
         // then
         assertThat(result).isEmpty();
-    }
-
-    public static Group makeGroup(String name, LocalDateTime createdDate) {
-        return Group.builder()
-                .name(name)
-                .createdDate(createdDate)
-                .build();
     }
 }

--- a/src/test/java/com/team7/spliito_server/service/PaymentServiceTest.java
+++ b/src/test/java/com/team7/spliito_server/service/PaymentServiceTest.java
@@ -52,9 +52,9 @@ class PaymentServiceTest extends IntegrationTestSupport {
         // given
         LocalDateTime now = LocalDateTime.of(2024, 10, 27, 0, 0, 0);
 
-        Group g1 = makeGroup("g1", now);
-        Group g2 = makeGroup("g2", now.plusDays(1));
-        Group g3 = makeGroup("g3", now.plusDays(2));
+        Group g1 = new Group("g1", now);
+        Group g2 = new Group("g2", now.plusDays(1));
+        Group g3 = new Group("g3", now.plusDays(2));
         List<Group> groups = groupRepository.saveAll(List.of(g1, g2, g3));
 
         User u1 = new User("u1", groups.get(0));
@@ -93,9 +93,9 @@ class PaymentServiceTest extends IntegrationTestSupport {
         // given
         LocalDateTime now = LocalDateTime.of(2024, 10, 27, 0, 0, 0);
 
-        Group g1 = makeGroup("g1", now);
-        Group g2 = makeGroup("g2", now.plusDays(1));
-        Group g3 = makeGroup("g3", now.plusDays(2));
+        Group g1 = new Group("g1", now);
+        Group g2 = new Group("g2", now.plusDays(1));
+        Group g3 = new Group("g3", now.plusDays(2));
         List<Group> groups = groupRepository.saveAll(List.of(g1, g2, g3));
 
         User u1 = new User("u1", groups.get(0));
@@ -134,9 +134,9 @@ class PaymentServiceTest extends IntegrationTestSupport {
         // given
         LocalDateTime now = LocalDateTime.of(2024, 10, 27, 0, 0, 0);
 
-        Group g1 = makeGroup("g1", now);
-        Group g2 = makeGroup("g2", now.plusDays(1));
-        Group g3 = makeGroup("g3", now.plusDays(2));
+        Group g1 = new Group("g1", now);
+        Group g2 = new Group("g2", now.plusDays(1));
+        Group g3 = new Group("g3", now.plusDays(2));
         List<Group> groups = groupRepository.saveAll(List.of(g1, g2, g3));
 
         User u1 = new User("u1", groups.get(0));
@@ -164,9 +164,9 @@ class PaymentServiceTest extends IntegrationTestSupport {
         // given
         LocalDateTime now = LocalDateTime.of(2024, 10, 27, 0, 0, 0);
 
-        Group g1 = makeGroup("g1", now);
-        Group g2 = makeGroup("g2", now.plusDays(1));
-        Group g3 = makeGroup("g3", now.plusDays(2));
+        Group g1 = new Group("g1", now);
+        Group g2 = new Group("g2", now.plusDays(1));
+        Group g3 = new Group("g3", now.plusDays(2));
         List<Group> groups = groupRepository.saveAll(List.of(g1, g2, g3));
 
         User u1 = new User("u1", groups.get(0));
@@ -195,9 +195,9 @@ class PaymentServiceTest extends IntegrationTestSupport {
         // given
         LocalDateTime now = LocalDateTime.of(2024, 10, 27, 0, 0, 0);
 
-        Group g1 = makeGroup("g1", now);
-        Group g2 = makeGroup("g2", now.plusDays(1));
-        Group g3 = makeGroup("g3", now.plusDays(2));
+        Group g1 = new Group("g1", now);
+        Group g2 = new Group("g2", now.plusDays(1));
+        Group g3 = new Group("g3", now.plusDays(2));
         List<Group> groups = groupRepository.saveAll(List.of(g1, g2, g3));
 
         User u1 = new User("u1", groups.get(0));
@@ -218,14 +218,5 @@ class PaymentServiceTest extends IntegrationTestSupport {
         assertThatThrownBy(() -> paymentService.addPayment(groupId, request, now))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("그룹에 존재하지 않는 유저입니다!");
-    }
-
-
-
-    public static Group makeGroup(String name, LocalDateTime createdDate) {
-        return Group.builder()
-                .name(name)
-                .createdDate(createdDate)
-                .build();
     }
 }


### PR DESCRIPTION
- 그룹 생성 시 createdDate도 같이 생성하도록 변경
- 그룹 생성 API 명세서대로 request field 이름 memberNames > memberName으로 변경

현재 쿠버네티스 작업은 백 기준 외부 DB와 연결 완료 후 정상 작동 확인했고, 리버스 프록시 위한 Nginx 연동했습니다 (아키텍처 부분에 Nginx가 없기는 한데, 알아보니까 쿠버네티스 생태계에서 프록시 위해서는 Nginx 또는 Nginx Ingress Controller를 배치해야 해서 넣었습니다. 빼려면 언제든지 뺄 수 있습니다)

프로메테우스랑 그라파나는 정상 작동 확인 후 Nginx 정보 가져오는 것까지 확인했는데 (당시 스프링 없이 우선 Nginx-프로메테우스-그라파나 연동 작업부터 했습니다), 스프링 작업 중 Nginx와 Spring Namespace를 변경하니 프로메테우스가 CrashBackOff가 뜨네요 아마 Namespace 이슈일 거 같은데 내일 프로메테우스 정상 작동 후 Nginx 포함해서 스프링 정보 가져오는 것까지 해보겟습니다


 