### PR TITLE
쿠버네티스 미사용 namespace 제거

### DIFF
--- a/kubernetes/monitoring/grafana/grafana-namespace.yaml
+++ b/kubernetes/monitoring/grafana/grafana-namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion : v1
-kind : Namespace
-metadata:
-  name : splitway-grafana

--- a/kubernetes/monitoring/prometheus/prometheus-namespace.yaml
+++ b/kubernetes/monitoring/prometheus/prometheus-namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion : v1
-kind : Namespace
-metadata:
-  name : splitway-prometheus


### PR DESCRIPTION
splitway-backend와 splitway-monitoring 이외 미사용 namespace 제거